### PR TITLE
Dev.html ahora apunta a Mapea 5.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,10 +25,6 @@ Plugin que va a la extensión y posición original del mapa base.
   - 'BL':bottom left
   - 'BR':bottom right
 
-## Eventos
-
-## Otros métodos
-
 ## Ejemplos de uso
 
 ### Ejemplo 1
@@ -49,7 +45,7 @@ Plugin que va a la extensión y posición original del mapa base.
     container: 'map'
   }); 
 
-  const mp = new M.plugin.MaxExtZoom({});
+  const mp = new M.plugin.MaxExtZoom();
 
   map.addPlugin(mp);
 ```

--- a/test/dev.html
+++ b/test/dev.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="mapea" content="yes">
     <title>MaxExtZoom TEST</title>
-    <link href="http://sigc-dev.desarrollo.guadaltel.es/mapea5/assets/css/mapea-5.2.0.ol.min.css" rel="stylesheet" />
+    <link href="http://mapea4-sigc.juntadeandalucia.es/mapea/assets/css/mapea-5.1.0.ol.min.css" rel="stylesheet" />
     <style rel="stylesheet">
         html,
         body {
@@ -22,8 +22,8 @@
 
 <body>
     <div id="mapjs" class="container"></div>
-    <script type="text/javascript" src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/mapea-5.2.0.ol.min.js"></script>
-    <script type="text/javascript" src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/configuration-5.2.0.js"></script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/mapea-5.1.0.ol.min.js"></script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/configuration-5.1.0.js"></script>
     <script type="text/javascript" src="/main.js"></script>
 
 </body>


### PR DESCRIPTION
Corregidos los enlaces de dev.html para que apunte a la versión 5.1 de Mapea.